### PR TITLE
Remove redundant call to cleanValue

### DIFF
--- a/odometer.coffee
+++ b/odometer.coffee
@@ -95,7 +95,7 @@ class Odometer
               @inside["outer#{ property }"]
 
             set: (val) =>
-              @update @cleanValue val
+              @update val
     catch e
       # Safari
       @watchForMutations()


### PR DESCRIPTION
cleanValue (on a value) is called in update method so I think it should be removed here
