### PR TITLE
Removed Arimo font css from Plaza theme

### DIFF
--- a/sass/odometer-theme-plaza.sass
+++ b/sass/odometer-theme-plaza.sass
@@ -1,6 +1,5 @@
 @import compass/css3
 @import mixins
-@import url("//fonts.googleapis.com/css?family=Arimo")
 
 $themeName: "odometer-theme-plaza"
 $digitPadding: .03em


### PR DESCRIPTION
It's not used anyway, but the browser requests the css file from google
