### PR TITLE
Correct check for global `exports` for commonJS and Browserify

### DIFF
--- a/odometer.coffee
+++ b/odometer.coffee
@@ -551,7 +551,7 @@ if typeof define is 'function' and define.amd
   # AMD. Register as an anonymous module.
   define ['jquery'], ->
     Odometer
-else if typeof exports is not 'undefined'
+else if exports?
   # CommonJS
   module.exports = Odometer
 else


### PR DESCRIPTION
``` coffee
typeof exports is not 'undefined'
```

Translates into:

``` js
(typeof exports === !'undefined')
```

Definitely not what we want.

Instead, using [`exports?`](http://stackoverflow.com/a/10238211/790169) which will properly translate to... 

``` js
(typeof exports !== 'undefined' && exports !== null)
```
