### PR TITLE
Fix zero length string radix in old versions of IE8

### DIFF
--- a/odometer.js
+++ b/odometer.js
@@ -270,6 +270,9 @@
       }
       _ref1 = parsed.slice(1, 4), repeating = _ref1[0], radix = _ref1[1], fractional = _ref1[2];
       precision = (fractional != null ? fractional.length : void 0) || 0;
+      if( typeof radix === "string" && radix.length === 0 ){
+          radix = null;
+      }
       return this.format = {
         repeating: repeating,
         radix: radix,


### PR DESCRIPTION
In Internet Explorer 8, radix will in certain circumstances be a zero length string, and thus break the parsing of the number.

This fixes that.

Yes I know the minified file is not updated and neither the .coffee file.
