### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,13 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-compass": "~0.5.0",
     "color": "~0.4.4"
+  },
+  "spm": {
+    "main": "odometer.js",
+    "ignore": [
+      "docs",
+      "sass",
+      "test"
+    ]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/odometer

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of odometer in spmjs, I can add it for your account after signing in http://spmjs.io.
