### PR TITLE
Fixed: AMD exporting issues

### DIFF
--- a/odometer.js
+++ b/odometer.js
@@ -640,12 +640,13 @@
     }, false);
   }
 
-  if (typeof define === 'function' && define.amd) {
-    define(['jquery'], function() {
+  if (typeof exports !== "undefined" && exports !== null) {
+    module.exports = Odometer;
+  }
+  else if (typeof define === 'function' && define.amd) {
+    define(window.jQuery && ['jquery'], function() {
       return Odometer;
     });
-  } else if (typeof exports !== "undefined" && exports !== null) {
-    module.exports = Odometer;
   } else {
     window.Odometer = Odometer;
   }


### PR DESCRIPTION
1. When built as an npm module by webpack - gets exported by default as an AMD module, which gives error:  "Uncaught Error: define cannot be used indirect" - changed commonJS schema to be first in the exporting format order

2. Exporting as amd module does not check jquery's presence