### PR TITLE
Fix digit shifting

### DIFF
--- a/sass/_mixins.sass
+++ b/sass/_mixins.sass
@@ -32,6 +32,7 @@
 
             .odometer-value
                 display: block
+                width: 100%
                 -webkit-transform: translateZ(0)
 
                 &.odometer-last-value


### PR DESCRIPTION
This solution when using not default font-family for odometer. https://github.com/HubSpot/odometer/issues/137